### PR TITLE
設定画面で課金モードを変更できるように改修

### DIFF
--- a/src/isChargeModeBucket.ts
+++ b/src/isChargeModeBucket.ts
@@ -11,7 +11,7 @@ type IsChargeModeObjType = {
 
 type IsChargeModeFnType = {
   getIsChargeMode: () => Promise<boolean>;
-  handleIsChargeMode: (modeBoolean: boolean) => void;
+  handleIsChargeMode: (modeBoolean: boolean) => Promise<void>;
 };
 
 /**
@@ -22,7 +22,7 @@ type IsChargeModeFnType = {
  * @returns boolean
  */
 const isChargeModeTypeObjToBool = (modeObj: IsChargeModeObjType): boolean => {
-  return Boolean(modeObj.mode);
+  return modeObj.mode === 'true';
 };
 
 /**
@@ -63,8 +63,8 @@ export const isChargeModeFn = (): IsChargeModeFnType => {
    *
    * @param modeBoolean 課金mode true: 従量課金mode false: APIキーmode
    */
-  const handleIsChargeMode = (modeBoolean: boolean) => {
-    isChargeModeBucket.set(isChargeModeTypeStrToObj(modeBoolean));
+  const handleIsChargeMode = async (modeBoolean: boolean) => {
+    await isChargeModeBucket.set(isChargeModeTypeStrToObj(modeBoolean));
   };
 
   return {

--- a/src/isChargeModeBucket.ts
+++ b/src/isChargeModeBucket.ts
@@ -1,0 +1,74 @@
+import { getBucket } from '@extend-chrome/storage';
+
+enum IsChargeModeStrEnum {
+  CHARGEMODE = 'true',
+  APIKEYMODE = 'false',
+}
+
+type IsChargeModeObjType = {
+  mode: IsChargeModeStrEnum;
+};
+
+type IsChargeModeFnType = {
+  getIsChargeMode: () => Promise<boolean>;
+  handleIsChargeMode: (modeBoolean: boolean) => void;
+};
+
+/**
+ * IsChargeModeObjType to boolean
+ *
+ * @param modeObj IsChargeModeObjType
+ *
+ * @returns boolean
+ */
+const isChargeModeTypeObjToBool = (modeObj: IsChargeModeObjType): boolean => {
+  return Boolean(modeObj.mode);
+};
+
+/**
+ * boolean to IsChargeModeObjType
+ *
+ * @param modeBoolean boolean
+ *
+ * @returns IsChargeModeObjType
+ */
+const isChargeModeTypeStrToObj = (modeBoolean: boolean): IsChargeModeObjType => {
+  return { mode: modeBoolean ? IsChargeModeStrEnum.CHARGEMODE : IsChargeModeStrEnum.APIKEYMODE };
+};
+
+/**
+ * 課金modeの状態を保持する
+ */
+const isChargeModeBucket = getBucket<IsChargeModeObjType>('isChargeMode', 'sync');
+
+/**
+ * 課金modeの取得・更新
+ *
+ * @returns getIsChargeMode: 課金modeの取得
+ * @returns handleIsChargeMode: 課金modeの更新
+ */
+export const isChargeModeFn = (): IsChargeModeFnType => {
+  /**
+   * 課金modeの取得
+   *
+   * @returns 課金mode true: 従量課金mode false: APIキーmode
+   */
+  const getIsChargeMode = async () => {
+    const nowModeObj = await isChargeModeBucket.get();
+    return isChargeModeTypeObjToBool(nowModeObj);
+  };
+
+  /**
+   * 課金modeの更新
+   *
+   * @param modeBoolean 課金mode true: 従量課金mode false: APIキーmode
+   */
+  const handleIsChargeMode = (modeBoolean: boolean) => {
+    isChargeModeBucket.set(isChargeModeTypeStrToObj(modeBoolean));
+  };
+
+  return {
+    getIsChargeMode,
+    handleIsChargeMode,
+  };
+};

--- a/src/popup/Apipop.tsx
+++ b/src/popup/Apipop.tsx
@@ -93,44 +93,44 @@ const Apipop = (): React.ReactElement => {
   };
 
   function judgeAPI() {
-    if (apikeys.judge) {
-      return (
-        <>
-          <div>APIKEYが保存されています</div>
-          <Button
-            sx={{ m: 2 }}
-            variant="contained"
-            onClick={deleteAPIKEY}
-            startIcon={<DeleteIcon />}
-          >
-            APIを削除
-          </Button>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <Box sx={{ mt: 2 }}>APIKeyを貼り付けてください</Box>
-          <TextField
-            id="outlined-basic"
-            label="APIKEY"
-            variant="outlined"
-            value={apikeys.api}
-            onChange={handleAPIChange}
-            sx={{ m: 1, width: 200 }}
-          />
-          <Stack direction="row" spacing={2} justifyContent="flex-end">
-            <Button variant="contained" onClick={saveAPIKEY} startIcon={<SaveIcon />}>
-              保存
+    return (
+      <Box sx={{ height: '150px' }}>
+        {apikeys.judge ? (
+          <>
+            <div>APIKEYが保存されています</div>
+            <Button
+              sx={{ m: 2 }}
+              variant="contained"
+              onClick={deleteAPIKEY}
+              startIcon={<DeleteIcon />}
+            >
+              APIを削除
             </Button>
-          </Stack>
-        </>
-      );
-    }
+          </>
+        ) : (
+          <>
+            <Box>APIKeyを貼り付けてください</Box>
+            <TextField
+              id="outlined-basic"
+              label="APIKEY"
+              variant="outlined"
+              value={apikeys.api}
+              onChange={handleAPIChange}
+              sx={{ m: 1, width: 200 }}
+            />
+            <Stack direction="row" spacing={2} justifyContent="flex-end">
+              <Button variant="contained" onClick={saveAPIKEY} startIcon={<SaveIcon />}>
+                保存
+              </Button>
+            </Stack>
+          </>
+        )}
+      </Box>
+    );
   }
 
   return (
-    <Box sx={{ m: 2, width: 200 }}>
+    <Box>
       {judgeAPI()}
       {/* <FormControl component="fieldset">
         <FormLabel component="legend">Model</FormLabel>

--- a/src/popup/ChangeModeHeader.tsx
+++ b/src/popup/ChangeModeHeader.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { Box, Button, Stack, Typography } from '@mui/material';
+
+export const ChargeModeHeader: FC = () => {
+  return (
+    <>
+      <Box>従量課金モード使用中</Box>
+      <Stack alignItems="flex-center" justifyContent="center" spacing={1} sx={{ mt: 2 }}>
+        <Box>
+          <Box>Status</Box>
+          <Typography>試験モード中</Typography>
+        </Box>
+        <Box>
+          <Box>Setting</Box>
+          <Button variant="contained" size="small" disabled startIcon={<SettingsIcon />}>
+            設定を開く
+          </Button>
+        </Box>
+      </Stack>
+    </>
+  );
+};

--- a/src/popup/ChargeModeSwitch.tsx
+++ b/src/popup/ChargeModeSwitch.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { Box, FormControl, FormControlLabel, FormLabel, Switch } from '@mui/material';
+
+type Props = {
+  isCheck: boolean;
+  handleChange: () => void;
+};
+
+export const ChargeModeSwitch: FC<Props> = ({ isCheck, handleChange }) => {
+  return (
+    <Box>
+      <FormControl>
+        <FormLabel focused={isCheck} sx={{ fontSize: '12px' }}>
+          従量課金モード
+        </FormLabel>
+        <FormControlLabel
+          control={<Switch checked={isCheck} onChange={handleChange} name="chargeModeSwitch" />}
+          label={isCheck ? 'ON' : 'OFF'}
+        />
+      </FormControl>
+    </Box>
+  );
+};

--- a/src/popup/Optionpop.tsx
+++ b/src/popup/Optionpop.tsx
@@ -8,7 +8,7 @@ const Optionpopup = (): React.ReactElement => {
     navigator.clipboard.writeText(text);
   };
   return (
-    <Box sx={{ m: 2 }} fontSize={12}>
+    <Box fontSize={12}>
       <div>追加いただきありがとうございます！</div>
       <div>
         ※使い方は
@@ -22,7 +22,7 @@ const Optionpopup = (): React.ReactElement => {
         </a>
         をご覧ください。
       </div>
-      <Box sx={{ my: 2 }}>
+      <Box>
         <div>製作者は、25卒で絶賛就活中です。</div>
         <div>
           興味を持っていただけた方は、メール作成アシスト powered by GPT-3.5を使って、

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -27,9 +27,9 @@ const Popup = (): React.ReactElement => {
   /**
    * 従量課金モードとAPIキーモードの切り替え
    */
-  const handleChangeMode = () => {
+  const handleChangeMode = async () => {
     setIsChargeMode(!isChargeMode);
-    handleIsChargeMode(!isChargeMode);
+    await handleIsChargeMode(!isChargeMode);
   };
 
   return (

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,17 +1,43 @@
-import React from 'react';
-import Box from '@mui/material/Box';
+import React, { useEffect, useState } from 'react';
+import { Box, Stack } from '@mui/material';
+
+import { isChargeModeFn } from '../isChargeModeBucket';
 
 import Apipop from './Apipop';
+import { ChargeModeHeader } from './ChangeModeHeader';
+import { ChargeModeSwitch } from './ChargeModeSwitch';
 import Optionpopup from './Optionpop';
 import Userpop from './Userpop';
 
 const Popup = (): React.ReactElement => {
+  const { getIsChargeMode, handleIsChargeMode } = isChargeModeFn();
+  const [isChargeMode, setIsChargeMode] = useState<boolean>(false);
+
+  /**
+   * modeState初期化
+   */
+  useEffect(() => {
+    const fetchMode = async () => {
+      const nowMode = await getIsChargeMode();
+      setIsChargeMode(nowMode);
+    };
+    fetchMode();
+  }, []);
+
+  /**
+   * 従量課金モードとAPIキーモードの切り替え
+   */
+  const handleChangeMode = () => {
+    setIsChargeMode(!isChargeMode);
+    handleIsChargeMode(!isChargeMode);
+  };
+
   return (
-    <Box>
-      {/* <Userpop /> */}
-      <Apipop />
+    <Stack spacing={1} sx={{ width: '250px', height: '450px', p: 3 }}>
+      <Box sx={{ height: '150px' }}> {isChargeMode ? <ChargeModeHeader /> : <Apipop />}</Box>
       <Optionpopup />
-    </Box>
+      <ChargeModeSwitch isCheck={isChargeMode} handleChange={handleChangeMode} />
+    </Stack>
   );
 };
 


### PR DESCRIPTION
## 目的
- 設定画面で、APIキーモード・従量課金モードを切り替えられる様に改修

## 実装内容
- 設定画面に`Switch`を設置
- スイッチで設定画面内のモード表示を切り替え

## 参考

### 動作の様子
https://github.com/shota-0129/Gmail_Extension/assets/109256327/82440107-7ae7-45ce-8a3e-7a997a09c6a5

### 比較
|before|after|
|---|---|
|<img width="332" alt="スクリーンショット 2023-08-01 22 58 14" src="https://github.com/shota-0129/Gmail_Extension/assets/109256327/cf950826-5cf2-46a4-bf71-b10debe7570f">|<img width="332" alt="スクリーンショット 2023-08-01 22 59 11" src="https://github.com/shota-0129/Gmail_Extension/assets/109256327/e00f56a5-50ec-494c-88aa-e3aa295eaf18">|
||<img width="332" alt="スクリーンショット 2023-08-01 22 59 14" src="https://github.com/shota-0129/Gmail_Extension/assets/109256327/517e9fe3-3d8b-4de8-944a-e952fe408009"> |